### PR TITLE
Some cleanups and tweaks.

### DIFF
--- a/vpnctl.go
+++ b/vpnctl.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"fmt"
-	//"flag"
-	"io"
 	"log"
 	"net"
 	"os"
@@ -56,12 +54,8 @@ func chkroot() {
 
 func vpnup(conf string) {
 	openvpn := exec.Command("openvpn", "--config", conf)
-
-	stdout, _ := openvpn.StdoutPipe()
-	stderr, _ := openvpn.StderrPipe()
-
-	go io.Copy(os.Stdout, stdout)
-	go io.Copy(os.Stderr, stderr)
+	openvpn.Stdout = os.Stdout
+	openvpn.Stderr = os.Stderr
 
 	err := openvpn.Start()
 	chk(err)

--- a/vpnctl.go
+++ b/vpnctl.go
@@ -40,10 +40,6 @@ func main() {
 	default:
 		vpnstat()
 	}
-
-	for {
-		time.Sleep(10000)
-	}
 }
 
 func chkroot(cmd string) {

--- a/vpnctl.go
+++ b/vpnctl.go
@@ -53,9 +53,9 @@ func vpnup(conf string) {
 	openvpn.Stdout = os.Stdout
 	openvpn.Stderr = os.Stderr
 
-	err := openvpn.Start()
+	err := openvpn.Run()
 	if err != nil {
-		log.Fatalf("vpnup: Failed to start openvpn: %v", err)
+		log.Fatalf("vpnup: openvpn failed: %v", err)
 	}
 }
 

--- a/vpnctl.go
+++ b/vpnctl.go
@@ -32,10 +32,10 @@ func main() {
 
 	switch cmd {
 	case "up":
-		chkroot()
+		chkroot("up")
 		vpnup(conf)
 	case "down":
-		chkroot()
+		chkroot("down")
 		//vpndown( conf )
 	default:
 		vpnstat()
@@ -46,9 +46,9 @@ func main() {
 	}
 }
 
-func chkroot() {
+func chkroot(cmd string) {
 	if os.Geteuid() != 0 {
-		log.Fatalln("Root permissions are required for this command.")
+		log.Fatalf("%v: Root permissions are required for this command.", cmd)
 	}
 }
 
@@ -58,12 +58,17 @@ func vpnup(conf string) {
 	openvpn.Stderr = os.Stderr
 
 	err := openvpn.Start()
-	chk(err)
+	if err != nil {
+		log.Fatalf("vpnup: Failed to start openvpn: %v", err)
+	}
 }
 
 func vpnstat() {
 	ifs, err := net.Interfaces()
-	chk(err)
+	if err != nil {
+		log.Fatalf("vpnstat: Failed to get interface info: %v", err)
+	}
+
 	parseInterfaces(ifs)
 }
 
@@ -71,12 +76,6 @@ func parseInterfaces(ifs []net.Interface) {
 	// tun, up, point-to-point -- what need
 	for n := 0; n < len(ifs); n++ {
 		fmt.Println(ifs[n].Name)
-	}
-}
-
-func chk(err error) {
-	if err != nil {
-		log.Fatal(err)
 	}
 }
 

--- a/vpnctl.go
+++ b/vpnctl.go
@@ -17,11 +17,11 @@ package main
 import (
 	"fmt"
 	//"flag"
+	"io"
 	"log"
 	"net"
 	"os"
 	"os/exec"
-	"io"
 	"time"
 )
 
@@ -29,14 +29,13 @@ import (
 // one to the current attempt. Using same, openvpn initialization fails.
 
 func main() {
-
-	conf := os.Args[ 1 ]
-	cmd := os.Args[ 2 ]
+	conf := os.Args[1]
+	cmd := os.Args[2]
 
 	switch cmd {
 	case "up":
 		chkroot()
-		vpnup( conf )
+		vpnup(conf)
 	case "down":
 		chkroot()
 		//vpndown( conf )
@@ -51,40 +50,39 @@ func main() {
 
 func chkroot() {
 	if os.Geteuid() != 0 {
-		log.Fatalln( "Root permissions are required for this command." )
+		log.Fatalln("Root permissions are required for this command.")
 	}
 }
 
-func vpnup( conf string ) {
+func vpnup(conf string) {
+	openvpn := exec.Command("openvpn", "--config", conf)
 
-	openvpn := exec.Command( "openvpn","--config",conf )
+	stdout, _ := openvpn.StdoutPipe()
+	stderr, _ := openvpn.StderrPipe()
 
-	stdout,_ := openvpn.StdoutPipe()
-	stderr,_ := openvpn.StderrPipe()
-
-	go io.Copy( os.Stdout,stdout )
-	go io.Copy( os.Stderr,stderr )
+	go io.Copy(os.Stdout, stdout)
+	go io.Copy(os.Stderr, stderr)
 
 	err := openvpn.Start()
-	chk( err )
+	chk(err)
 }
 
 func vpnstat() {
-	ifs,err := net.Interfaces();
-	chk( err )
-	parseInterfaces( ifs )
+	ifs, err := net.Interfaces()
+	chk(err)
+	parseInterfaces(ifs)
 }
 
-func parseInterfaces( ifs []net.Interface ){
+func parseInterfaces(ifs []net.Interface) {
 	// tun, up, point-to-point -- what need
-	for n := 0; n < len( ifs ); n++ {
-		fmt.Println( ifs[ n ].Name )
+	for n := 0; n < len(ifs); n++ {
+		fmt.Println(ifs[n].Name)
 	}
 }
 
-func chk( err error ) {
+func chk(err error) {
 	if err != nil {
-		log.Fatal( err )
+		log.Fatal(err)
 	}
 }
 

--- a/vpnctl.go
+++ b/vpnctl.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"time"
 )
 
 // Need to check for current tun devices, then assign the next highest


### PR DESCRIPTION
I assume the loop on line 47 that I removed was so that the two io.Copy() calls could continue running. Calling (*Cmd).Run() instead of (*Cmd).Start() will block until the command exits, achieving the same effect more efficiently.