### PR TITLE
Refactor command handling.

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+type Cmd interface {
+	Name() string
+	Desc() string
+
+	Run(Config) error
+}
+
+type Config struct {
+	Config string
+}
+
+type cmdList struct {
+	cmds []Cmd
+}
+
+var (
+	cmds cmdList
+)
+
+func RegisterCmd(cmd Cmd) {
+	cmds.cmds = append(cmds.cmds, cmd)
+	sort.Sort(&cmds)
+}
+
+func GetCmd(name string) Cmd {
+	i := sort.Search(len(cmds.cmds), func(i int) bool {
+		return cmds.cmds[i].Name() >= name
+	})
+
+	if (i < len(cmds.cmds)) && (cmds.cmds[i].Name() == name) {
+		return cmds.cmds[i]
+	}
+
+	return nil
+}
+
+func GetCmds() []Cmd {
+	return cmds.cmds
+}
+
+func (c *cmdList) Len() int {
+	return len(c.cmds)
+}
+
+func (c *cmdList) Swap(i1, i2 int) {
+	c.cmds[i1], c.cmds[i2] = c.cmds[i2], c.cmds[i1]
+}
+
+func (c *cmdList) Less(i1, i2 int) bool {
+	return c.cmds[i1].Name() < c.cmds[i2].Name()
+}
+
+type NeedRootError struct {
+	Cmd string
+}
+
+func (err NeedRootError) Error() string {
+	return fmt.Sprintf("Command %q needs root privileges.", err.Cmd)
+}

--- a/cmd_stat.go
+++ b/cmd_stat.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+func init() {
+	RegisterCmd(&statCmd{})
+}
+
+type statCmd struct {
+}
+
+func (c statCmd) Name() string {
+	return "stat"
+}
+
+func (c statCmd) Desc() string {
+	return "Gives information about the current status of the VPN."
+}
+
+func (c statCmd) filterTuns(ifs []net.Interface) []net.Interface {
+	tuns := make([]net.Interface, 0, len(ifs))
+	for n := 0; n < len(ifs); n++ {
+		netif := ifs[n]
+		name := netif.Name
+
+		isTun := len(name) > 2 && name[0:3] == "tun" &&
+			netif.Flags&net.FlagPointToPoint > 0
+
+		if isTun {
+			tuns = append(tuns, netif)
+		}
+	}
+	return tuns
+}
+
+func (c statCmd) Run(config Config) error {
+	ifs, err := net.Interfaces()
+	if err != nil {
+		return fmt.Errorf("vpnstat: Failed to get interface info: %v", err)
+	}
+
+	tuns := c.filterTuns(ifs)
+	fmt.Println(tuns)
+
+	return nil
+}

--- a/cmd_up.go
+++ b/cmd_up.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func init() {
+	RegisterCmd(&upCmd{})
+}
+
+type upCmd struct {
+}
+
+func (c upCmd) Name() string {
+	return "up"
+}
+
+func (c upCmd) Desc() string {
+	return "Brings OpenVPN up."
+}
+
+func (c upCmd) Run(config Config) error {
+	if !chkroot() {
+		return &NeedRootError{
+			Cmd: c.Name(),
+		}
+	}
+
+	openvpn := exec.Command("openvpn", "--config", config.Config)
+	openvpn.Stdout = os.Stdout
+	openvpn.Stderr = os.Stderr
+
+	err := openvpn.Run()
+	if err != nil {
+		return fmt.Errorf("OpenVPN failed: %v", err)
+	}
+
+	return nil
+}

--- a/vpnctl.go
+++ b/vpnctl.go
@@ -17,47 +17,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
-	"net"
 	"os"
-	"os/exec"
-	"sort"
 )
 
-type Command struct {
-	Name string
-	Desc string
+func chkroot() bool {
+	if os.Geteuid() != 0 {
+		return false
+	}
 
-	Run func(Config) error
-}
-
-type Config struct {
-	Config string
-}
-
-type CommandList struct {
-	cmds   []*Command
-	config Config
-}
-
-func (c *CommandList) Add(cmd *Command) {
-	c.cmds = append(c.cmds, cmd)
-	sort.Sort(c)
-}
-
-func (c *CommandList) Run(name string) error {
-}
-
-func (c *CommandList) Len() int {
-	return len(c.cmds)
-}
-
-func (c *CommandList) Swap(i1, i2 int) {
-	c.cmds[i1], c.cmds[i2] = c.cmds[i2], c.cmds[i1]
-}
-
-func (c *CommandList) Less(i1, i2 int) bool {
-	return c.cmds[i1].Name < c.cmds[i2].Name
+	return true
 }
 
 func main() {
@@ -69,11 +37,14 @@ vpnctl is a wrapper around OpenVPN.
 If no command is specified, status is displayed.
 
 Commands:
-	up:	Bring OpenVPN up.
-	down:	Bring OpenVPN down.
-
-Options:
 `, os.Args[0])
+
+		for _, cmd := range GetCmds() {
+			fmt.Fprintf(os.Stderr, "\t%v:\t%v\n", cmd.Name(), cmd.Desc())
+		}
+		fmt.Fprintln(os.Stderr)
+
+		fmt.Fprintf(os.Stderr, "Options:")
 		flag.PrintDefaults()
 	}
 
@@ -81,62 +52,27 @@ Options:
 	flag.StringVar(&config.Config, "conf", "", "The OpenVPN config to use.")
 
 	flag.Parse()
-
-	cmd := flag.Arg(1)
-
-	switch cmd {
-	case "up":
-		chkroot("up")
-		vpnup(*conf)
-	case "down":
-		chkroot("down")
-		//vpndown(*conf)
-	default:
-		vpnstat()
+	if flag.NArg() > 1 {
+		flag.Usage()
+		os.Exit(2)
 	}
-}
 
-func chkroot(cmd string) {
-	if os.Geteuid() != 0 {
-		log.Fatalf("%v: Root permissions are required for this command.", cmd)
+	cmdname := "stat"
+	if flag.NArg() == 1 {
+		cmdname = flag.Arg(0)
 	}
-}
 
-func vpnup(conf string) {
-	openvpn := exec.Command("openvpn", "--config", conf)
-	openvpn.Stdout = os.Stdout
-	openvpn.Stderr = os.Stderr
+	cmd := GetCmd(cmdname)
+	if cmd == nil {
+		fmt.Fprintf(os.Stderr, "Unknown command: %q\n", cmdname)
+		os.Exit(2)
+	}
 
-	err := openvpn.Run()
+	err := cmd.Run(config)
 	if err != nil {
-		log.Fatalf("vpnup: openvpn failed: %v", err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
 	}
-}
-
-func vpnstat() {
-	ifs, err := net.Interfaces()
-	if err != nil {
-		log.Fatalf("vpnstat: Failed to get interface info: %v", err)
-	}
-
-	tuns := filterTuns(ifs)
-	fmt.Println(tuns)
-}
-
-func filterTuns(ifs []net.Interface) []net.Interface {
-	tuns := make([]net.Interface, 0, len(ifs))
-	for n := 0; n < len(ifs); n++ {
-		netif := ifs[n]
-		name := netif.Name
-
-		isTun := len(name) > 2 && name[0:3] == "tun" &&
-			netif.Flags&net.FlagPointToPoint > 0
-
-		if isTun {
-			tuns = append(tuns, netif)
-		}
-	}
-	return tuns
 }
 
 // vim: noet tw=72 ts=3 sw=3

--- a/vpnctl.go
+++ b/vpnctl.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -23,16 +24,33 @@ import (
 )
 
 func main() {
-	conf := os.Args[1]
-	cmd := os.Args[2]
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, `Usage: %v [command]
+
+vpnctl is a wrapper around OpenVPN.
+
+If no command is specified, status is displayed.
+
+Commands:
+	up:	Bring OpenVPN up.
+	down:	Bring OpenVPN down.
+
+Options:
+`, os.Args[0])
+		flag.PrintDefaults()
+	}
+	conf := flag.String("conf", "", "The OpenVPN config to use.")
+	flag.Parse()
+
+	cmd := flag.Arg(1)
 
 	switch cmd {
 	case "up":
 		chkroot("up")
-		vpnup(conf)
+		vpnup(*conf)
 	case "down":
 		chkroot("down")
-		//vpndown( conf )
+		//vpndown(*conf)
 	default:
 		vpnstat()
 	}

--- a/vpnctl.go
+++ b/vpnctl.go
@@ -21,7 +21,44 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"sort"
 )
+
+type Command struct {
+	Name string
+	Desc string
+
+	Run func(Config) error
+}
+
+type Config struct {
+	Config string
+}
+
+type CommandList struct {
+	cmds   []*Command
+	config Config
+}
+
+func (c *CommandList) Add(cmd *Command) {
+	c.cmds = append(c.cmds, cmd)
+	sort.Sort(c)
+}
+
+func (c *CommandList) Run(name string) error {
+}
+
+func (c *CommandList) Len() int {
+	return len(c.cmds)
+}
+
+func (c *CommandList) Swap(i1, i2 int) {
+	c.cmds[i1], c.cmds[i2] = c.cmds[i2], c.cmds[i1]
+}
+
+func (c *CommandList) Less(i1, i2 int) bool {
+	return c.cmds[i1].Name < c.cmds[i2].Name
+}
 
 func main() {
 	flag.Usage = func() {
@@ -39,7 +76,10 @@ Options:
 `, os.Args[0])
 		flag.PrintDefaults()
 	}
-	conf := flag.String("conf", "", "The OpenVPN config to use.")
+
+	var config Config
+	flag.StringVar(&config.Config, "conf", "", "The OpenVPN config to use.")
+
 	flag.Parse()
 
 	cmd := flag.Arg(1)


### PR DESCRIPTION
This breaks the command handling code out into a more encapsulated design. This allows each command to be more fully self-contained.

Ideally, the commandList and related types and functions should be in a seperate package, maybe called 'command', but due to the way Go handles relative dependencies, that's hard for me to do in a fork. See golang/go#12502. I'll work on it, though.